### PR TITLE
Match the go version in the project go.mod.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 			"dockerDashComposeVersion": "latest"
 		},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.21.6"
+			"version": "1.22.1"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,


### PR DESCRIPTION
This will trim a few seconds off go re-downloading the version in the postcreate script. We should make sure this matches. 