### PR TITLE
chore: Update go to 1.22.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 			"dockerDashComposeVersion": "latest"
 		},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.22.1",
+			"version": "1.22.2",
 			"golangciLintVersion": "1.57.1"
 		},
 		"ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
Updated go to 1.22.2.

This fixes a known vulnerability. More info can be found in [https://github.com/daytonaio/daytona/pull/383](https://github.com/daytonaio/daytona/pull/383).